### PR TITLE
Feature/use global timer

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -28,78 +28,82 @@ describe("Name", () => {
     expect(image.src).toContain("test");
   });
 
-  it("staggers name changes to only fire request after user stops typing", async () => {
-    const image = await screen.findByAltText(
-      "A blank card with the 'Stinky' sigil"
-    );
+  it("staggers changes across multiple fields", async () => {});
 
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+  describe("staggering individual form fields", () => {
+    it("when name", async () => {
+      const image = await screen.findByAltText(
+        "A blank card with the 'Stinky' sigil"
+      );
 
-    const nameField = screen.getByRole("textbox", {
-      name: /Name/,
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+
+      const nameField = screen.getByRole("textbox", {
+        name: /Name/,
+      });
+
+      await act(async () => {
+        userEvent.type(nameField, "123456789");
+      });
+
+      jest.advanceTimersByTime(499);
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+
+      await act(async () => {
+        jest.advanceTimersByTime(2);
+      });
+
+      expect(image.src).toContain("HEAVYWEIGHT.ttf_128");
     });
 
-    await act(async () => {
-      userEvent.type(nameField, "123456789");
+    it("when power", async () => {
+      const image = await screen.findByAltText(
+        "A blank card with the 'Stinky' sigil"
+      );
+
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+      const powerField = screen.getByRole("spinbutton", {
+        name: /Power/,
+      });
+
+      await act(async () => {
+        userEvent.type(powerField, "123456789");
+      });
+
+      jest.advanceTimersByTime(499);
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+      await act(async () => {
+        jest.advanceTimersByTime(2);
+      });
+
+      expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
     });
 
-    jest.advanceTimersByTime(499);
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+    it("when health", async () => {
+      const image = await screen.findByAltText(
+        "A blank card with the 'Stinky' sigil"
+      );
 
-    await act(async () => {
-      jest.advanceTimersByTime(2);
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+      const healthField = screen.getByRole("spinbutton", {
+        name: /Health/,
+      });
+
+      await act(async () => {
+        userEvent.type(healthField, "123456789");
+      });
+
+      jest.advanceTimersByTime(499);
+      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+      await act(async () => {
+        jest.advanceTimersByTime(2);
+      });
+
+      expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
     });
-
-    expect(image.src).toContain("HEAVYWEIGHT.ttf_128");
-  });
-
-  it("staggers power changes to only fire request after user stops typing", async () => {
-    const image = await screen.findByAltText(
-      "A blank card with the 'Stinky' sigil"
-    );
-
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
-
-    const powerField = screen.getByRole("spinbutton", {
-      name: /Power/,
-    });
-
-    await act(async () => {
-      userEvent.type(powerField, "123456789");
-    });
-
-    jest.advanceTimersByTime(499);
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
-
-    await act(async () => {
-      jest.advanceTimersByTime(2);
-    });
-
-    expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
-  });
-
-  it("staggers health changes to only fire request after user stops typing", async () => {
-    const image = await screen.findByAltText(
-      "A blank card with the 'Stinky' sigil"
-    );
-
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
-
-    const healthField = screen.getByRole("spinbutton", {
-      name: /Health/,
-    });
-
-    await act(async () => {
-      userEvent.type(healthField, "123456789");
-    });
-
-    jest.advanceTimersByTime(499);
-    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
-
-    await act(async () => {
-      jest.advanceTimersByTime(2);
-    });
-
-    expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -52,4 +52,54 @@ describe("Name", () => {
 
     expect(image.src).toContain("HEAVYWEIGHT.ttf_128");
   });
+
+  it("staggers power changes to only fire request after user stops typing", async () => {
+    const image = await screen.findByAltText(
+      "A blank card with the 'Stinky' sigil"
+    );
+
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+    const powerField = screen.getByRole("spinbutton", {
+      name: /Power/,
+    });
+
+    await act(async () => {
+      userEvent.type(powerField, "123456789");
+    });
+
+    jest.advanceTimersByTime(499);
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+    await act(async () => {
+      jest.advanceTimersByTime(2);
+    });
+
+    expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
+  });
+
+  it("staggers health changes to only fire request after user stops typing", async () => {
+    const image = await screen.findByAltText(
+      "A blank card with the 'Stinky' sigil"
+    );
+
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+    const healthField = screen.getByRole("spinbutton", {
+      name: /Health/,
+    });
+
+    await act(async () => {
+      userEvent.type(healthField, "123456789");
+    });
+
+    jest.advanceTimersByTime(499);
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+
+    await act(async () => {
+      jest.advanceTimersByTime(2);
+    });
+
+    expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
+  });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -28,7 +28,46 @@ describe("Name", () => {
     expect(image.src).toContain("test");
   });
 
-  it("staggers changes across multiple fields", async () => {});
+  it("staggers changes across multiple fields", async () => {
+    const image = await screen.findByAltText(
+      "A blank card with the 'Stinky' sigil"
+    );
+
+    const nameField = screen.getByRole("textbox", {
+      name: /Name/,
+    });
+
+    const powerField = screen.getByRole("spinbutton", {
+      name: /Power/,
+    });
+
+    expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf/);
+
+    await act(async () => {
+      userEvent.type(nameField, "123456789");
+    });
+
+    jest.advanceTimersByTime(499);
+    expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf/);
+
+    // Make a change before timer runs out
+    await act(async () => {
+      userEvent.type(powerField, "123456789");
+    });
+
+    // Confirm that image does not change
+    jest.advanceTimersByTime(499);
+    expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf/);
+
+    // Allow timer to finish
+    await act(async () => {
+      jest.advanceTimersByTime(2);
+    });
+
+    // Confirm image contains both transformations
+    expect(image.src).toMatch(/HEAVYWEIGHT.ttf_128/);
+    expect(image.src).toMatch(/HEAVYWEIGHT.ttf_156/);
+  });
 
   describe("staggering individual form fields", () => {
     it("when name", async () => {
@@ -36,7 +75,7 @@ describe("Name", () => {
         "A blank card with the 'Stinky' sigil"
       );
 
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_128/);
 
       const nameField = screen.getByRole("textbox", {
         name: /Name/,
@@ -47,13 +86,13 @@ describe("Name", () => {
       });
 
       jest.advanceTimersByTime(499);
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_128/);
 
       await act(async () => {
         jest.advanceTimersByTime(2);
       });
 
-      expect(image.src).toContain("HEAVYWEIGHT.ttf_128");
+      expect(image.src).toMatch(/HEAVYWEIGHT.ttf_128/);
     });
 
     it("when power", async () => {
@@ -61,7 +100,7 @@ describe("Name", () => {
         "A blank card with the 'Stinky' sigil"
       );
 
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_156/);
 
       const powerField = screen.getByRole("spinbutton", {
         name: /Power/,
@@ -72,13 +111,13 @@ describe("Name", () => {
       });
 
       jest.advanceTimersByTime(499);
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_156/);
 
       await act(async () => {
         jest.advanceTimersByTime(2);
       });
 
-      expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).toMatch(/HEAVYWEIGHT.ttf_156/);
     });
 
     it("when health", async () => {
@@ -86,7 +125,7 @@ describe("Name", () => {
         "A blank card with the 'Stinky' sigil"
       );
 
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_156/);
 
       const healthField = screen.getByRole("spinbutton", {
         name: /Health/,
@@ -97,13 +136,13 @@ describe("Name", () => {
       });
 
       jest.advanceTimersByTime(499);
-      expect(image.src).not.toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).not.toMatch(/HEAVYWEIGHT.ttf_156/);
 
       await act(async () => {
         jest.advanceTimersByTime(2);
       });
 
-      expect(image.src).toContain("HEAVYWEIGHT.ttf_156");
+      expect(image.src).toMatch(/HEAVYWEIGHT.ttf_156/);
     });
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,55 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import * as constants from "../components/constants";
+import Home from "../pages";
+
+describe("Name", () => {
+  constants.CLOUDINARY_BASE = "https://test/";
+
+  beforeEach(async () => {
+    render(<Home />);
+
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("mocks the image url to avoid contacting cloudinary", async () => {
+    const image = await screen.findByAltText(
+      "A blank card with the 'Stinky' sigil"
+    );
+
+    expect(image.src).not.toContain("cloudinary");
+    expect(image.src).toContain("test");
+  });
+
+  it("staggers name changes to only fire request after user stops typing", async () => {
+    const image = await screen.findByAltText(
+      "A blank card with the 'Stinky' sigil"
+    );
+
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+
+    const nameField = screen.getByRole("textbox", {
+      name: /Name/,
+    });
+
+    await act(async () => {
+      userEvent.type(nameField, "123456789");
+    });
+
+    jest.advanceTimersByTime(499);
+    expect(image.src).not.toContain("HEAVYWEIGHT.ttf_128");
+
+    await act(async () => {
+      jest.advanceTimersByTime(2);
+    });
+
+    expect(image.src).toContain("HEAVYWEIGHT.ttf_128");
+  });
+});

--- a/__tests__/name.test.js
+++ b/__tests__/name.test.js
@@ -71,18 +71,6 @@ describe("Name", () => {
     });
   });
 
-  it("staggers requests to only fire after user stops typing", async () => {
-    const nameField = screen.getByRole("textbox", {
-      name: /Name/,
-    });
-
-    userEvent.type(nameField, "Test String LONG LONG LONG LONG LONG LONG");
-
-    await waitFor(() => {
-      expect(mockCallback).toHaveBeenCalledTimes(1);
-    });
-  });
-
   it("completely removes the transformation when field is empty", async () => {
     const nameField = screen.getByRole("textbox", {
       name: /Name/,
@@ -100,7 +88,6 @@ describe("Name", () => {
 
     await waitFor(() => {
       expect(mockCallback).toHaveBeenCalledWith("");
-      expect(mockCallback).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/__tests__/stats.test.js
+++ b/__tests__/stats.test.js
@@ -79,18 +79,6 @@ describe("Stats", () => {
       });
     });
 
-    it("staggers requests to only fire after user stops typing", async () => {
-      const powerField = screen.getByRole("spinbutton", {
-        name: /Power/,
-      });
-
-      userEvent.type(powerField, "12345678901234567890");
-
-      await waitFor(() => {
-        expect(mockCallback).toHaveBeenCalledTimes(1);
-      });
-    });
-
     it("completely removes the transformation when field is empty", async () => {
       const powerField = screen.getByRole("spinbutton", {
         name: /Power/,
@@ -108,7 +96,6 @@ describe("Stats", () => {
 
       await waitFor(() => {
         expect(mockCallback).toHaveBeenCalledWith("");
-        expect(mockCallback).toHaveBeenCalledTimes(2);
       });
     });
   });
@@ -154,18 +141,6 @@ describe("Stats", () => {
       });
     });
 
-    it("staggers requests to only fire after user stops typing", async () => {
-      const healthField = screen.getByRole("spinbutton", {
-        name: /Health/,
-      });
-
-      userEvent.type(healthField, "12345678901234567890");
-
-      await waitFor(() => {
-        expect(mockCallback).toHaveBeenCalledTimes(1);
-      });
-    });
-
     it("completely removes the transformation when field is empty", async () => {
       const healthField = screen.getByRole("spinbutton", {
         name: /Health/,
@@ -183,7 +158,6 @@ describe("Stats", () => {
 
       await waitFor(() => {
         expect(mockCallback).toHaveBeenCalledWith("");
-        expect(mockCallback).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/components/name.js
+++ b/components/name.js
@@ -4,29 +4,22 @@ import { HEAVYWEIGHT } from "./constants";
 
 const Name = (props) => {
   const [name, setName] = useState("");
-  const [timer, setTimer] = useState(null);
   const { setNameTF } = props;
 
   // Stagger requests so they only send 500ms after user stops typing
   const nameChanged = (e) => {
     const newName = e.target.value;
-
     setName(newName);
-    clearTimeout(timer);
 
-    const newTimer = setTimeout(() => {
-      // If name is empty, clear transformation to save load on API
-      newName === ""
-        ? setNameTF("")
-        : setNameTF(
-            `l_text:${HEAVYWEIGHT}_128:` +
-              `${encodeURIComponent(newName)},` +
-              `g_north,y_48,w_600,h_116,` +
-              `c_${newName.length < 10 ? "fit" : "scale"}/`
-          );
-    }, 500);
-
-    setTimer(newTimer);
+    // If name is empty, clear transformation to save load on API
+    newName === ""
+      ? setNameTF("")
+      : setNameTF(
+          `l_text:${HEAVYWEIGHT}_128:` +
+            `${encodeURIComponent(newName)},` +
+            `g_north,y_48,w_600,h_116,` +
+            `c_${newName.length < 10 ? "fit" : "scale"}/`
+        );
   };
 
   return (

--- a/components/name.js
+++ b/components/name.js
@@ -6,7 +6,6 @@ const Name = (props) => {
   const [name, setName] = useState("");
   const { setNameTF } = props;
 
-  // Stagger requests so they only send 500ms after user stops typing
   const nameChanged = (e) => {
     const newName = e.target.value;
     setName(newName);

--- a/components/stats.js
+++ b/components/stats.js
@@ -5,7 +5,6 @@ import { HEAVYWEIGHT } from "./constants";
 const Stats = (props) => {
   const [power, setPower] = useState("");
   const [health, setHealth] = useState("");
-  const [timer, setTimer] = useState(null);
   const { setPowerTF, setHealthTF } = props;
 
   // Stagger requests so they only send 500ms after user stops typing
@@ -13,40 +12,28 @@ const Stats = (props) => {
     const newPower = e.target.value;
     setPower(newPower);
 
-    clearTimeout(timer);
-
-    const newTimer = setTimeout(() => {
-      newPower === ""
-        ? setPowerTF("")
-        : setPowerTF(
-            `l_text:${HEAVYWEIGHT}_156:` +
-              `${encodeURIComponent(newPower)},` +
-              `g_south_west,x_64,y_164,w_100,h_156,` +
-              `c_${newPower.length < 2 ? "fit" : "scale"}/`
-          );
-    }, 500);
-
-    setTimer(newTimer);
+    newPower === ""
+      ? setPowerTF("")
+      : setPowerTF(
+          `l_text:${HEAVYWEIGHT}_156:` +
+            `${encodeURIComponent(newPower)},` +
+            `g_south_west,x_64,y_164,w_100,h_156,` +
+            `c_${newPower.length < 2 ? "fit" : "scale"}/`
+        );
   };
 
   const healthChanged = (e) => {
     const newHealth = e.target.value;
     setHealth(newHealth);
 
-    clearTimeout(timer);
-
-    const newTimer = setTimeout(() => {
-      newHealth === ""
-        ? setHealthTF("")
-        : setHealthTF(
-            `l_text:${HEAVYWEIGHT}_156:` +
-              `${encodeURIComponent(newHealth)},` +
-              `g_south_east,x_64,y_56,w_100,h_156,` +
-              `c_${newHealth.length < 2 ? "fit" : "scale"}/`
-          );
-    }, 500);
-
-    setTimer(newTimer);
+    newHealth === ""
+      ? setHealthTF("")
+      : setHealthTF(
+          `l_text:${HEAVYWEIGHT}_156:` +
+            `${encodeURIComponent(newHealth)},` +
+            `g_south_east,x_64,y_56,w_100,h_156,` +
+            `c_${newHealth.length < 2 ? "fit" : "scale"}/`
+        );
   };
 
   return (

--- a/components/stats.js
+++ b/components/stats.js
@@ -7,7 +7,6 @@ const Stats = (props) => {
   const [health, setHealth] = useState("");
   const { setPowerTF, setHealthTF } = props;
 
-  // Stagger requests so they only send 500ms after user stops typing
   const powerChanged = (e) => {
     const newPower = e.target.value;
     setPower(newPower);

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,7 @@ export default function Home() {
   const [powerTF, setPowerTF] = useState("");
   const [healthTF, setHealthTF] = useState("");
 
+  // Stagger requests so they only send 500ms after user stops typing
   useEffect(() => {
     const timer = setTimeout(() => {
       setBusy(true);

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,9 +16,12 @@ export default function Home() {
   const [url, setUrl] = useState(`${CLOUDINARY_BASE}${CARD_BASE}`);
 
   useEffect(() => {
-    setBusy(true);
-
-    setUrl(`${CLOUDINARY_BASE}${nameTF}${powerTF}${healthTF}${CARD_BASE}`);
+    const timer = setTimeout(() => {
+      setBusy(true);
+      const transformations = [nameTF, powerTF, healthTF].join();
+      setUrl(`/${transformations}${CARD_BASE}`);
+    }, 500);
+    return () => clearTimeout(timer);
   }, [nameTF, powerTF, healthTF]);
 
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,7 +19,7 @@ export default function Home() {
     const timer = setTimeout(() => {
       setBusy(true);
       const transformations = [nameTF, powerTF, healthTF].join();
-      setUrl(`/${transformations}${CARD_BASE}`);
+      setUrl(`${CLOUDINARY_BASE}${transformations}${CARD_BASE}`);
     }, 500);
     return () => clearTimeout(timer);
   }, [nameTF, powerTF, healthTF]);
@@ -135,6 +135,7 @@ export default function Home() {
               height={0}
               layout={busy ? 0 : "fill"}
               objectFit="contain"
+              priority
               onLoadingComplete={() => {
                 setBusy(false);
               }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,14 +6,14 @@ import Name from "../components/name";
 import Stats from "../components/stats";
 
 export default function Home() {
+  // State management for this component
+  const [url, setUrl] = useState(`${CLOUDINARY_BASE}${CARD_BASE}`);
+  const [busy, setBusy] = useState(true);
+
   // Transformations to be applied to the image
   const [nameTF, setNameTF] = useState("");
   const [powerTF, setPowerTF] = useState("");
   const [healthTF, setHealthTF] = useState("");
-
-  // State management for this component
-  const [busy, setBusy] = useState(true);
-  const [url, setUrl] = useState(`${CLOUDINARY_BASE}${CARD_BASE}`);
 
   useEffect(() => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
- [x] Removes mutliple timers, moves them into global index page
- [x] Updates fireOnce specs to be within the timed component - form fields test they generate transformations correctly, index tests they send them appropriately