### PR TITLE
Spike/cloudinary GitHub actions

### DIFF
--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo '${{ steps.jq-filter.outputs.RESOURCES }} | jq ".[] | public_id"'
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES.*.public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,8 +29,8 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
       - name: DEBUG raw cloudinary output
-        run: echo "${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}
       - name: DEBUG "resources" from response
-        run: echo "${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}"
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response.resources) }}
       - name: DEBUG filtered files from cloudinary
-        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"
+        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response.resources.*.public_id) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
           data: "{ 'expression':'folder=Inscryption/Uploads' }"
-          method: "GET"
+          method: "POST"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Log files from cloudinary

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -27,10 +27,12 @@ jobs:
           method: "POST"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+      - name: Filter output with jq
+        run: echo steps.cloudinaryRequest.outputs.response | jq '.[].resources'
 
-      - name: DEBUG raw cloudinary output
-        run: echo ${{ steps.cloudinaryRequest.outputs.response }}
-      - name: DEBUG "resources" from response
-        run: echo ${{ steps.cloudinaryRequest.outputs.response }}.resources
+      # - name: DEBUG raw cloudinary output
+      #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}
+      # - name: DEBUG "resources" from response
+      #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}.resources
       # - name: DEBUG filtered files from cloudinary
       #   run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -19,19 +19,40 @@ jobs:
       # more than an hour old"
       # https://cloudinary.com/documentation/search_api#expressions
       - name: Retrieve files in cloudinary
-        id: cloudinaryRequest
+        id: get-request
         uses: fjogeleit/http-request-action@master
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
           data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at>1h" }'
-          method: "POST"
+          method: 'POST'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+
+      # Output of this response returns full metadata for each image. We don't need
+      # most of it, so use command line tool JQ to build an array of public IDs.
+      # This is stored as an output so we can use in later steps
       - name: Filter output with jq
         id: jq-filter
-        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources | .[].public_id')
-      - name: Log jq variable
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.get-request.outputs.response) }} | jq '.resources | .[].public_id')
+
+      - name: Delete selected files
+        uses: fjogeleit/http-request-action@master
+        id: delete-request
+        with:
+          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
+          data: ${{ join(steps.jq-filter.outputs.RESOURCES, "public_ids[]=") }}
+          method: 'DELETE'
+          username: ${{ secrets.CLOUDINARY_API_KEY }}
+          password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+
+      - name: DEBUG Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
+
+      - name: DEBUG Log joined ids
+        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, "public_ids[]=") }}
+
+      - name: DEBUG log delete response
+        run: echo ${{ steps.delete-request.outputs.response }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,7 +28,10 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources'
+        id: jq-filter
+        run: echo "::set-output name=resources::${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources'"
+      - name: Log jq variable
+        run: echo "JQ output is ${{ steps.jq-filter.outputs.resources }}"
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -32,6 +32,8 @@ jobs:
         run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
+      - name: Log filtered variable
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES.*.public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -26,7 +26,7 @@ jobs:
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://api.cloudinary.com/v1_1/$CLOUD_NAME/folders
+          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/folders
           method: "GET"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES.*.public_id, '\n') }}
+        run: echo ${{ toJSON(steps.jq-filter.outputs.RESOURCES).*.public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -19,7 +19,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
-          data: "{ 'expression':'folder=Inscryption/Uploads' }"
+          data: '{ "expression": "folder=Inscryption/Uploads" }'
           method: "POST"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -35,6 +35,12 @@ jobs:
         id: jq-filter
         run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.get-request.outputs.response) }} | jq '.resources | .[].public_id')
 
+      - name: DEBUG Log jq variable
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
+
+      - name: DEBUG Log joined ids
+        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
+
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master
         id: delete-request
@@ -44,12 +50,6 @@ jobs:
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
-
-      - name: DEBUG Log jq variable
-        run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
-
-      - name: DEBUG Log joined ids
-        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
 
       - name: DEBUG log delete response
         run: echo ${{ steps.delete-request.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -46,7 +46,7 @@ jobs:
         id: delete-request
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/image/upload
-          data: ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
+          data: "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ', public_ids[]=') }}"
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -14,11 +14,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      env:
+        API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+        SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+        CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://${{secrets.CLOUDINARY_API_KEY}}:${{secrets.CLOUDINARY_API_SECRET_KEY}}@api.cloudinary.com/v1_1/${{secrets.CLOUDINARY_CLOUD_NAME}}/folders
+          url: https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
           method: "POST"
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       # This is stored as an output so we can use in later steps
       - name: Filter output with jq
         id: jq-filter
-        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.get-request.outputs.response) }} | jq '.resources | .[].public_id')
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.get-request.outputs.response) }} | jq '.resources | [.[].public_id]')
 
       - name: DEBUG Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo "RESOURCES=$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')" >> $GITHUB_ENV
+        run: echo "RESOURCES=$(echo toJSON(steps.cloudinaryRequest.outputs.response) | jq '.resources')" >> $GITHUB_ENV
       - name: Log jq variable
         run: echo $RESOURCES
 

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -23,7 +23,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
-          data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at<1h" }'
+          data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at>1h" }'
           method: "POST"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,10 +28,9 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        id: jq-filter
-        run: echo "::set-output name=resources::${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources'"
+        run: echo "RESOURCES=$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')" >> $GITHUB_ENV
       - name: Log jq variable
-        run: echo "JQ output is ${{ steps.jq-filter.outputs.resources }}"
+        run: echo $RESOURCES
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -18,7 +18,7 @@ jobs:
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://${{secrets.CLOUDINARY_API_KEY}}:${{secrets.CLOUDINARY_API_SECRET_KEY}}@api.cloudinary.com/v1_1/${{secrets.CLOUDINARY_CLOUD_NAME}}/resources/image
+          url: https://${{secrets.CLOUDINARY_API_KEY}}:${{secrets.CLOUDINARY_API_SECRET_KEY}}@api.cloudinary.com/v1_1/${{secrets.CLOUDINARY_CLOUD_NAME}}/folders
           method: "POST"
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -26,9 +26,7 @@ jobs:
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
+          url: "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
           method: "GET"
-          username: $API_KEY
-          password: $SECRET_KEY
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.[].resources'
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources'
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo ${{ steps.jq-filter.outputs.RESOURCES.*.public_id }}
+        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES.*.public_id, '\n') }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -20,13 +20,15 @@ jobs:
     steps:
       - name: Log encrypted env vars
         run: echo "$API_KEY -> $SECRET_KEY -> $CLOUD_NAME"
-      - name: Log url
+      - name: Curl url
         run: curl https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
+          url: "https://api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
           method: "POST"
+          username: $API_KEY
+          password: $SECRET_KEY
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -31,6 +31,6 @@ jobs:
       - name: DEBUG raw cloudinary output
         run: echo ${{ steps.cloudinaryRequest.outputs.response }}
       - name: DEBUG "resources" from response
-        run: echo ${{ steps.cloudinaryRequest.outputs.response.resources }}
-      - name: DEBUG filtered files from cloudinary
-        run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}
+      # - name: DEBUG filtered files from cloudinary
+      #   run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -14,14 +14,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # The "expression" body argument is built using the Cloudinary search API
+      # It translates to "find images in the Inscryption/Uploads folder that are
+      # more than an hour old"
+      # https://cloudinary.com/documentation/search_api#expressions
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
-          data: '{ "expression": "folder=Inscryption/Uploads" }'
+          data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at<1h" }'
           method: "POST"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
-      - name: Log files from cloudinary
-        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"
+
+      - name: DEBUG Log files from cloudinary
+        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,11 +29,9 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
         id: jq-filter
-        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources | .[].public_id')
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
-      - name: Log filtered variable
-        run: echo ${{ steps.jq-filter.outputs.RESOURCES[0].public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo ${{ steps.cloudinaryRequest.outputs.response }} | jq '.[].resources'
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.[].resources'
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo ${{ steps.jq-filter.outputs.RESOURCES }} | jq '.[] | public_id'
+        run: echo '${{ steps.jq-filter.outputs.RESOURCES }} | jq ".[] | public_id"'
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -1,12 +1,12 @@
-# This workflow lists all images in the cloudinary upload folder
-# & deletes older ones.
+# Lists all images in the cloudinary upload folder & deletes those more than a day old.
+# When no files are found to be deleted, the delete request returns "not found"
 
-# Runs every monday @ 9am
+# Runs every day @ 5pm
 name: Cloudinary Cleanup
 
 on:
   schedule:
-    - cron: "0 9 * * MON"
+    - cron: "0 17 * * *"
   # Enables manual run from the Actions tab in GH
   workflow_dispatch:
 
@@ -41,6 +41,8 @@ jobs:
       - name: LOG joined public IDs to be sent to DELETE request
         run: echo "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), '&public_ids[]=') }}"
 
+      # Send request with ids to delete as 'application/x-www-form-urlencoded' content.
+      # IDs are joined with the `public_ids[]` key.
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master
         id: delete-request
@@ -54,10 +56,3 @@ jobs:
 
       - name: LOG response from DELETE request
         run: echo ${{ steps.delete-request.outputs.response }}
-
-      # - name: DEBUG raw cloudinary output
-      #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}
-      # - name: DEBUG "resources" from response
-      #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}.resources
-      # - name: DEBUG filtered files from cloudinary
-      #   run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo steps.cloudinaryRequest.outputs.response | jq '.[].resources'
+        run: echo ${{ steps.cloudinaryRequest.outputs.response }} | jq '.[].resources'
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,11 +29,9 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
         id: jq-filter
-        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources' | jq 'with_entries(select([.key] | inside(["public_key"])))')
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
-      - name: Log filtered variable
-        run: echo ${{ toJSON(steps.jq-filter.outputs.RESOURCES).*.public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,8 +29,8 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
       - name: DEBUG raw cloudinary output
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}
+        run: echo ${{ steps.cloudinaryRequest.outputs.response }}
       - name: DEBUG "resources" from response
-        run: echo ${{ toJSON(fromJSON(steps.cloudinaryRequest.outputs.response).resources) }}
+        run: echo ${{ steps.cloudinaryRequest.outputs.response.resources }}
       - name: DEBUG filtered files from cloudinary
-        run: echo "Images are ${{ toJSON(fromJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id) }}"
+        run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,14 +39,14 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ', public_ids[]=') }}"
+        run: echo "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), '&public_ids[]=') }}"
 
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master
         id: delete-request
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/image/upload
-          data: "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ', public_ids[]=') }}"
+          data: "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), '&public_ids[]=') }}"
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # The "expression" body argument is built using the Cloudinary search API
       # It translates to "find images in the Inscryption/Uploads folder that are
-      # more than an hour old"
+      # more than a day old"
       # https://cloudinary.com/documentation/search_api#expressions
       - name: Retrieve files in cloudinary
         id: get-request

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo 'public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ", public_ids[]=") }}''
+        run: echo "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ', public_ids[]=') }}"
 
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -13,20 +13,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-      SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
-      CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
     steps:
-      - name: Log encrypted env vars
-        run: echo "$API_KEY -> $SECRET_KEY -> $CLOUD_NAME"
-      - name: Curl url
-        run: curl https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/folders
+          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
+          data: "{ 'expression':'folder=Inscryption/Uploads' }"
           method: "GET"
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,5 +28,9 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
-      - name: DEBUG Log files from cloudinary
+      - name: DEBUG raw cloudinary output
+        run: echo "${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"
+      - name: DEBUG "resources" from response
+        run echo "${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}"
+      - name: DEBUG filtered files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
+        run: echo ${{ join(toJSON(steps.jq-filter.outputs.RESOURCES), 'public_ids[]=') }}
 
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -31,6 +31,6 @@ jobs:
       - name: DEBUG raw cloudinary output
         run: echo "${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"
       - name: DEBUG "resources" from response
-        run echo "${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}"
+        run: echo "${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}"
       - name: DEBUG filtered files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -40,7 +40,7 @@ jobs:
         id: delete-request
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/image/upload
-          data: ${{ join(steps.jq-filter.outputs.RESOURCES, ",") }}
+          data: ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
@@ -49,7 +49,7 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, "public_ids[]=") }}
+        run: echo ${{ join(steps.jq-filter.outputs.RESOURCES, 'public_ids[]=') }}
 
       - name: DEBUG log delete response
         run: echo ${{ steps.delete-request.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,8 +39,8 @@ jobs:
         uses: fjogeleit/http-request-action@master
         id: delete-request
         with:
-          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
-          data: ${{ join(steps.jq-filter.outputs.RESOURCES, "public_ids[]=") }}
+          url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/image/upload
+          data: ${{ join(steps.jq-filter.outputs.RESOURCES, ",") }}
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,9 +29,11 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
         id: jq-filter
-        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources' | jq 'with_entries(select([.key] | inside(["public_key"])))')
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
+      - name: Log filtered variable
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES }} | jq '.[] | public_id'
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/image/upload
           data: "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), '&public_ids[]=') }}"
+          contentType: 'application/x-www-form-urlencoded'
           method: 'DELETE'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Log encrypted env vars
+        run: echo "${{ secrets.CLOUDINARY_API_KEY }} -> ${{ secrets.CLOUDINARY_API_SECRET_KEY }} -> ${{ secrets.CLOUDINARY_CLOUD_NAME }}"
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo ${{ toJSON(steps.jq-filter.outputs.RESOURCES).*.public_id }}
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES[0].public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -26,7 +26,7 @@ jobs:
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
+          url: https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
           method: "GET"
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -31,6 +31,6 @@ jobs:
       - name: DEBUG raw cloudinary output
         run: echo ${{ steps.cloudinaryRequest.outputs.response }}
       - name: DEBUG "resources" from response
-        run: echo ${{ steps.cloudinaryRequest.outputs.response.resources }}
+        run: echo ${{ steps.cloudinaryRequest.outputs.response }}.resources
       # - name: DEBUG filtered files from cloudinary
       #   run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,8 +29,8 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
       - name: DEBUG raw cloudinary output
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}
+        run: echo ${{ fromJSON(steps.cloudinaryRequest.outputs.response) }}
       - name: DEBUG "resources" from response
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response.resources) }}
+        run: echo ${{ fromJSON(steps.cloudinaryRequest.outputs.response).resources }}
       - name: DEBUG filtered files from cloudinary
-        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response.resources.*.public_id) }}"
+        run: echo "Images are ${{ fromJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -13,18 +13,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+      SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+      CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
     steps:
       - name: Log encrypted env vars
-        run: echo "${{ secrets.CLOUDINARY_API_KEY }} -> ${{ secrets.CLOUDINARY_API_SECRET_KEY }} -> ${{ secrets.CLOUDINARY_CLOUD_NAME }}"
+        run: echo "$API_KEY -> $SECRET_KEY -> $CLOUD_NAME"
+      - name: Log url
+        run: echo "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
-        env:
-          API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-          SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
-          CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
         with:
-          url: https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
+          url: "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
           method: "POST"
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Log encrypted env vars
         run: echo "$API_KEY -> $SECRET_KEY -> $CLOUD_NAME"
       - name: Log url
-        run: echo "https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
+        run: curl https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Log jq variable
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
       - name: Log filtered variable
-        run: echo ${{ steps.jq-filter.outputs.RESOURCES.*.public_id }}
+        run: echo ${{ toJSON(steps.jq-filter.outputs.RESOURCES).*.public_id }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -31,6 +31,6 @@ jobs:
       - name: DEBUG raw cloudinary output
         run: echo ${{ steps.cloudinaryRequest.outputs.response }}
       - name: DEBUG "resources" from response
-        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response).resources }}
+        run: echo ${{ steps.cloudinaryRequest.outputs.response.resources }}
       # - name: DEBUG filtered files from cloudinary
       #   run: echo "Images are ${{ steps.cloudinaryRequest.outputs.response.resources.*.public_id }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -26,7 +26,9 @@ jobs:
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
         with:
-          url: https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
+          url: https://api.cloudinary.com/v1_1/$CLOUD_NAME/folders
           method: "GET"
+          username: ${{ secrets.CLOUDINARY_API_KEY }}
+          password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Log files from cloudinary
         run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -23,7 +23,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           url: https://api.cloudinary.com/v1_1/${{ secrets.CLOUDINARY_CLOUD_NAME }}/resources/search
-          data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at>1h" }'
+          data: '{ "expression": "folder=Inscryption/Uploads AND uploaded_at<1d" }'
           method: 'POST'
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
@@ -35,10 +35,10 @@ jobs:
         id: jq-filter
         run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.get-request.outputs.response) }} | jq '.resources | [.[].public_id]')
 
-      - name: DEBUG Log jq variable
+      - name: LOG all IDs to be deleted
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
-      - name: DEBUG Log joined ids
+      - name: LOG joined public IDs to be sent to DELETE request
         run: echo "public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), '&public_ids[]=') }}"
 
       - name: Delete selected files
@@ -52,7 +52,7 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
-      - name: DEBUG log delete response
+      - name: LOG response from DELETE request
         run: echo ${{ steps.delete-request.outputs.response }}
 
       # - name: DEBUG raw cloudinary output

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -29,8 +29,8 @@ jobs:
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
 
       - name: DEBUG raw cloudinary output
-        run: echo ${{ fromJSON(steps.cloudinaryRequest.outputs.response) }}
+        run: echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}
       - name: DEBUG "resources" from response
-        run: echo ${{ fromJSON(steps.cloudinaryRequest.outputs.response).resources }}
+        run: echo ${{ toJSON(fromJSON(steps.cloudinaryRequest.outputs.response).resources) }}
       - name: DEBUG filtered files from cloudinary
-        run: echo "Images are ${{ fromJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id }}"
+        run: echo "Images are ${{ toJSON(fromJSON(steps.cloudinaryRequest.outputs.response).resources.*.public_id) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -27,7 +27,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           url: "https://api.cloudinary.com/v1_1/$CLOUD_NAME/folders"
-          method: "POST"
+          method: "GET"
           username: $API_KEY
           password: $SECRET_KEY
       - name: Log files from cloudinary

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -14,5 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Debug env vars
-        run: echo "Cloud name is ${{secrets.CLOUDINARY_CLOUD_NAME}}"
+      - name: Retrieve files in cloudinary
+        id: cloudinaryRequest
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: https://${{secrets.CLOUDINARY_API_KEY}}:${{secrets.CLOUDINARY_API_SECRET_KEY}}@api.cloudinary.com/v1_1/${{secrets.CLOUDINARY_CLOUD_NAME}}/resources/image
+          method: "POST"
+      - name: Log files from cloudinary
+        run: echo "Images are ${{ toJSON(steps.cloudinaryRequest.outputs.response) }}"

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo ${{ join(toJSON(steps.jq-filter.outputs.RESOURCES), 'public_ids[]=') }}
+        run: echo ${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), 'public_ids[]=') }}
 
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -28,9 +28,10 @@ jobs:
           username: ${{ secrets.CLOUDINARY_API_KEY }}
           password: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
       - name: Filter output with jq
-        run: echo "RESOURCES=$(echo toJSON(steps.cloudinaryRequest.outputs.response) | jq '.resources')" >> $GITHUB_ENV
+        id: jq-filter
+        run: echo ::set-output name=RESOURCES::$(echo ${{ toJSON(steps.cloudinaryRequest.outputs.response) }} | jq '.resources')
       - name: Log jq variable
-        run: echo $RESOURCES
+        run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       # - name: DEBUG raw cloudinary output
       #   run: echo ${{ steps.cloudinaryRequest.outputs.response }}

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ steps.jq-filter.outputs.RESOURCES }}
 
       - name: DEBUG Log joined ids
-        run: echo ${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), 'public_ids[]=') }}
+        run: echo 'public_ids[]=${{ join(fromJSON(steps.jq-filter.outputs.RESOURCES), ", public_ids[]=") }}''
 
       - name: Delete selected files
         uses: fjogeleit/http-request-action@master

--- a/.github/workflows/cloudinary_cleanup.yml
+++ b/.github/workflows/cloudinary_cleanup.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      env:
-        API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-        SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
-        CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
       - name: Retrieve files in cloudinary
         id: cloudinaryRequest
         uses: fjogeleit/http-request-action@master
+        env:
+          API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          SECRET_KEY: ${{ secrets.CLOUDINARY_API_SECRET_KEY }}
+          CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
         with:
           url: https://$API_KEY:$SECRET_KEY@api.cloudinary.com/v1_1/$CLOUD_NAME/folders
           method: "POST"

--- a/README.md
+++ b/README.md
@@ -23,3 +23,39 @@ Styling is built using [Tailwind](https://tailwindcss.com/); designs should be c
 ## Deployment
 
 The app is hosted via [Netlify](https://www.netlify.com/), which runs helpful checks for dead links prior to deployment. It also spins up temporary instances for each pull request, which can be used to test changes in a live environment.
+
+## GitHub Actions
+
+There are two actions associated with this repo.
+
+### `Run Tests`
+
+#### What
+
+This is fairly self explanatory. Uses the `test-ci` command defined in `package.json` to run tests without watching them.
+
+Helpful to catch any failures that could be missed.
+
+#### When
+
+Runs when any pull request is opened against or change is made to `main` branch.
+
+### `Cloudinary Cleanup`
+
+#### What
+
+To generate the `portrait` transformation, user images are uploaded to the `Inscryption/Uploads` folder on cloudinary. These are not needed after the user session closes (or indeed, able to be accessed) so need to be cleared to save storage space.
+
+This job has three key steps:
+
+1. Query the Cloudinary `search` API for any uploaded images in that subfolder that were uploaded more than a day ago
+2. Use `jq` to format the response to this query and retrieve the `public_id`'s of these uploads
+3. Query the cloudinary `admin` API to delete these files
+
+As this is rate limited, there is a fallback via the UI. Talk to @delete-44 about this if it becomes an issue.
+
+Environment variables such as authentication secrets are stored in the GitHub [action secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+
+#### When
+
+This job runs every day @ 5pm. Emails will be sent to collaborators in event of failure.


### PR DESCRIPTION
- [x] Adds GH action to read all files in the `Inscryption/Uploads` folder on cloudinary that are > 1 day old, and delete them
- [x] To test, visit [this action](https://github.com/delete-44/inscryber/actions/workflows/cloudinary_cleanup.yml) and click "Run workflow" from `spike/....`
- You may need to refresh page to see your new workflow
![image](https://user-images.githubusercontent.com/45462299/154118561-4ec43dbd-c16e-4a66-bbda-100676c364db.png)

---

Edit:
Also, an example of it actually working: https://github.com/delete-44/inscryber/runs/5204443886?check_suite_focus=true